### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/14](https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs actions like checking out the repository and running unit tests, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents.

The `permissions` block will be added at the top level of the workflow, ensuring that all jobs in the workflow inherit these minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
