### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,4 +1,6 @@
 name: Code Analysis
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/13](https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum permissions required. Since the workflow primarily performs code analysis and does not modify repository contents, the `contents: read` permission is sufficient. This will ensure that the workflow has only the permissions it needs and no more.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
