### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,9 @@ on:
         default: '21'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/12](https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the tasks performed in the workflow (e.g., checking out the code and caching dependencies). This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
