### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-and-cache.yml


### PR DESCRIPTION
Potential fix for [https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/7](https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for the workflow. Based on the provided workflow, the jobs primarily involve building, testing, and code analysis. These tasks typically require only `contents: read` permissions. If any job requires additional permissions, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
