### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-cache.yml
+++ b/.github/workflows/build-and-cache.yml
@@ -1,4 +1,6 @@
 name: Build and Cache
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/9](https://github.com/renansouza-dev/folio-app-backends/security/code-scanning/9)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's actions, it primarily reads repository contents and caches dependencies. Therefore, the `contents: read` permission is sufficient. If additional permissions are required for caching, they can be added later.

The `permissions` block should be added at the top level of the workflow file, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
